### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ACMagnifyingGlass is a magnifier like the one you can find in the _notes_ iOS app when moving the cursor.
 
 [![Build Status](https://api.travis-ci.org/acoomans/iOS-MagnifyingGlass.png)](https://api.travis-ci.org/acoomans/iOS-MagnifyingGlass.png)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/v/iOS-MagnifyingGlass/badge.png)](http://beta.cocoapods.org/?q=on%3Aios%20name%3AiOS-MagnifyingGlass%2A)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/p/iOS-MagnifyingGlass/badge.png)](http://beta.cocoapods.org/?q=on%3Aios%20name%3AiOS-MagnifyingGlass%2A)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/iOS-MagnifyingGlass/badge.png)](http://beta.cocoapods.org/?q=on%3Aios%20name%3AiOS-MagnifyingGlass%2A)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/p/iOS-MagnifyingGlass/badge.png)](http://beta.cocoapods.org/?q=on%3Aios%20name%3AiOS-MagnifyingGlass%2A)
 
 ![screenshots](https://github.com/acoomans/iOS-MagnifyingGlass/raw/master/MagnifyingGlassDemo/screenshot.png)
  


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
